### PR TITLE
[main] dropni constrainty pred COPY

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,7 +141,6 @@ if __name__ == "__main__":
                     )
                     for fk in dbtable.constraints:
                         if isinstance(fk, ForeignKeyConstraint):
-                            breakpoint()
                             DropConstraint(fk).execute(engine)
 
                 if engine.name == "postgresql":


### PR DESCRIPTION
Při vytváření tabulek dropne constrainty (FK, indexy, PK), který po copy přidá. Dramaticky to zrychluje nahrávání u tabulek s vícero constrainty, ale je třeba to ještě otestovat. Nezkoušel jsem:

- SQLite
- datasety jiný než PSP